### PR TITLE
Fix MSBuildTasks.Targets was trying to be loaded before nuget

### DIFF
--- a/DotNetNuke.Modules.Feedback.vbproj
+++ b/DotNetNuke.Modules.Feedback.vbproj
@@ -436,7 +436,6 @@
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.VisualBasic.targets" />
-  <Import Project="$(MSBuildProjectDirectory)\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" />
   <Import Project="$(MSBuildProjectDirectory)\_buildfiles\PackageModule.targets" />
   <PropertyGroup>
     <PreBuildEvent>


### PR DESCRIPTION
### Description of PR...
Fixes an issue where the project file was trying to import MSBuildTasks.Targets before it was pulled from nuget package restore.

## Changes made
- Removed duplicate Import in project file that tried to load the file before the nuget package restore

## PR Template Checklist

- [ ] Fixes Bug
- [ ] Feature solution
- [x] Other


## Please mark which issue is solved

Close #35 