### PR TITLE
Changed max length on body from 10 to 1000

### DIFF
--- a/Feedback.ascx
+++ b/Feedback.ascx
@@ -119,7 +119,7 @@
             <div id="divMessage" runat="server" class="Feedback_Field">
                 <div class="dnnFormItem">
 			        <dnn:label id="plMessage" runat="server" associatedcontrolid="txtBody" resourcekey="plMessage" ></dnn:label>
-			        <asp:textbox id="txtBody" runat="server"  textmode="Multiline" rows="10" MaxLength="10" ></asp:textbox>
+			        <asp:textbox id="txtBody" runat="server"  textmode="Multiline" rows="10" MaxLength="1000" ></asp:textbox>
 			        <asp:requiredfieldvalidator id="valMessage" runat="server" cssclass="dnnFormMessage dnnFormError" display="Dynamic" errormessage="Message is required"
 				        controltovalidate="txtBody" InitialValue="" Enabled="false" resourcekey="valBody.Error"></asp:requiredfieldvalidator>
                     <asp:RegularExpressionValidator ID="valMessageLength" runat="server" cssclass="dnnFormMessage dnnFormError" display="Dynamic" ControlToValidate="txtBody" ValidationExpression="^[\s\S]{0,50}$"


### PR DESCRIPTION
### Description of PR...
Fixing the maxlength 10 problem with the body of a message in DNN 9.4.1

## Changes made
- Changed MaxLength="10" to MaxLength="1000" on the txtBody input field.


## PR Template Checklist
- [X ] Fixes Bug


## Please mark which issue is solved
#51 

Close #